### PR TITLE
Fix some clear methods

### DIFF
--- a/lib/src/reader.dart
+++ b/lib/src/reader.dart
@@ -75,9 +75,9 @@ class _AnsiReader implements AnsiReader {
       case 'J':
         switch (value) {
           case '0':
-            return _listener.clearScreenBefore();
-          case '1':
             return _listener.clearScreenAfter();
+          case '1':
+            return _listener.clearScreenBefore();
           case '2':
             return _listener.clearScreen();
         }
@@ -85,9 +85,9 @@ class _AnsiReader implements AnsiReader {
       case 'K':
         switch (value) {
           case '0':
-            return _listener.clearLineBefore();
-          case '1':
             return _listener.clearLineAfter();
+          case '1':
+            return _listener.clearLineBefore();
           case '2':
             return _listener.clearLine();
         }

--- a/lib/src/writer.dart
+++ b/lib/src/writer.dart
@@ -32,19 +32,19 @@ abstract class AnsiWriter implements AnsiListener, StringSink {
   void clearScreen() => _writeEscape('2', 'J');
 
   @override
-  void clearScreenBefore() => _writeEscape('0', 'J');
+  void clearScreenAfter() => _writeEscape('0', 'J');
 
   @override
-  void clearScreenAfter() => _writeEscape('1', 'J');
+  void clearScreenBefore() => _writeEscape('1', 'J');
 
   @override
   void clearLine() => _writeEscape('2', 'K');
 
   @override
-  void clearLineBefore() => _writeEscape('0', 'K');
+  void clearLineAfter() => _writeEscape('0', 'K');
 
   @override
-  void clearLineAfter() => _writeEscape('1', 'K');
+  void clearLineBefore() => _writeEscape('1', 'K');
 
   @override
   void resetStyles() => _writeEscape('0', 'm');

--- a/test/writer_test.dart
+++ b/test/writer_test.dart
@@ -24,10 +24,10 @@ void main() {
       expect(readEscaped(), r'\u001b[2J');
 
       ioSink.clearScreenBefore();
-      expect(readEscaped(), r'\u001b[0J');
+      expect(readEscaped(), r'\u001b[1J');
 
       ioSink.clearScreenAfter();
-      expect(readEscaped(), r'\u001b[1J');
+      expect(readEscaped(), r'\u001b[0J');
     });
 
     test('should write the escape sequence for clearing the line', () {
@@ -35,10 +35,10 @@ void main() {
       expect(readEscaped(), r'\u001b[2K');
 
       ioSink.clearLineBefore();
-      expect(readEscaped(), r'\u001b[0K');
+      expect(readEscaped(), r'\u001b[1K');
 
       ioSink.clearLineAfter();
-      expect(readEscaped(), r'\u001b[1K');
+      expect(readEscaped(), r'\u001b[0K');
     });
 
     test('should write the escape sequence for resetting styles', () {


### PR DESCRIPTION
The clearScreenAfter / clearScreenBefore and clearLineAfter / clearLineBefore methods were swapped, this PR fixes their order.

A simple program showing the issue:

```dart
import 'dart:io';

import 'package:neoansi/neoansi.dart';

void main(List<String> args) async {
  final console = AnsiWriter.from(stdout);

  console.write('#########\n' * 3);
  console.moveCursorUp(2);
  console.moveCursorRight(4);
  if (args.single == 'clearLineAfter') {
    console.clearLineAfter();
  } else if (args.single == 'clearLineBefore') {
    console.clearLineBefore();
  } else if (args.single == 'clearScreenAfter') {
    console.clearScreenAfter();
  } else if (args.single == 'clearScreenBefore') {
    console.clearScreenBefore();
  }

  console.write('\r');
  console.moveCursorDown(2);
}
```

After this change we get the expected result:

```
> dart clear.dart clearLineAfter
#########
####
#########
> dart clear.dart clearLineBefore
#########
     ####
#########
> dart clear.dart clearScreenBefore

     ####
#########
> dart clear.dart clearScreenAfter 
#########
####

```